### PR TITLE
Add HWADDR+UUID network configuration cleanup script for CentOS

### DIFF
--- a/sysprep-op-network.sh
+++ b/sysprep-op-network.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Remove any HWADDR or UUID parameters from network configuration
+#
+# CentOS 7 is setting the MAC address as HWADDR parameter in the network
+# configuration files (/etc/sysconfig/network-scripts/ifcfg-e*)
+# [ifcfg-enp0s31f6, ifcfg-eth0]
+# It may also add UUID which should be also removed.
+
+set -o errexit
+
+network_config_locations=(
+    "/etc/sysconfig/network-scripts/ifcfg-e*"
+)
+
+# Include hidden files in glob
+shopt -s nullglob dotglob
+
+for network_config in "${network_config_locations[@]}"; do
+    sed -i '/^(HWADDR|UUID)=/d' "${network_config}"
+done
+
+exit 0


### PR DESCRIPTION
CentOS 7 is creating the network config file with MAC address - which should be removed:

```bash
[vagrant@localhost ~]$ cat /etc/os-release
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

[vagrant@localhost ~]$ ls -la /etc/sysconfig/network-scripts/ifcfg-e*
-rw-r--r--. 1 root root 161 Mar 27 16:46 /etc/sysconfig/network-scripts/ifcfg-enp0s3

[vagrant@localhost ~]$ cat /etc/sysconfig/network-scripts/ifcfg-enp0s3
# Created by cloud-init on instance boot automatically, do not edit.
#
BOOTPROTO=dhcp
DEVICE=enp0s3
HWADDR=08:00:27:10:68:cd
ONBOOT=yes
TYPE=Ethernet
USERCTL=no
```

Solution:

```bash
sed -i '/^(HWADDR|UUID)=/d' /etc/sysconfig/network-scripts/ifcfg-e*
```